### PR TITLE
Run npm install if package.json exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sqlfluff-templater-dataform-full"
-version = "0.1.2"
+version = "0.1.3"
 requires-python = ">=3.9"
 description = "Lint your Dataform project SQL"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
This PR enhances the Dataform templater to copy `package.json` and run `npm install` if the file exists. This ensures that Dataform projects with Node.js dependencies are correctly compiled.