### PR TITLE
Add support for more Dataform action types

### DIFF
--- a/test/fixtures/dataform/dataform_project/definitions/input/assertion.sqlx
+++ b/test/fixtures/dataform/dataform_project/definitions/input/assertion.sqlx
@@ -1,0 +1,5 @@
+config {
+  type: "assertion"
+}
+
+SELECT * FROM ${ref("table_a")} WHERE col IS NULL

--- a/test/fixtures/dataform/dataform_project/definitions/input/declaration.sqlx
+++ b/test/fixtures/dataform/dataform_project/definitions/input/declaration.sqlx
@@ -1,0 +1,9 @@
+config {
+  type: "declaration",
+  database: "project",
+  schema: "dataset",
+  name: "table_x"
+}
+
+-- This is a comment that should be preserved.
+-- TODO: Check if this linting works.

--- a/test/fixtures/dataform/dataform_project/definitions/input/incremental.sqlx
+++ b/test/fixtures/dataform/dataform_project/definitions/input/incremental.sqlx
@@ -1,0 +1,5 @@
+config {
+  type: "incremental"
+}
+-- This inserts `1` the first time running, and `2` on subsequent runs.
+SELECT ${when(incremental(), 1, 2) } AS col

--- a/test/fixtures/dataform/dataform_project/definitions/input/pre_post_ops.sqlx
+++ b/test/fixtures/dataform/dataform_project/definitions/input/pre_post_ops.sqlx
@@ -1,0 +1,17 @@
+config {
+  type: "table"
+}
+
+pre_operations {
+  GRANT `roles/bigquery.dataViewer`
+  ON TABLE ${ref("table_a")}
+  TO "group:automation@example.com"
+}
+
+post_operations {
+  REVOKE `roles/bigquery.dataViewer`
+  ON TABLE ${ref("table_a")}
+  TO "group:automation@example.com"
+}
+
+SELECT 1 AS test

--- a/test/fixtures/dataform/dataform_project/definitions/input/test_case.sqlx
+++ b/test/fixtures/dataform/dataform_project/definitions/input/test_case.sqlx
@@ -1,0 +1,14 @@
+config {
+  type: "test",
+  dataset: "config_query"
+}
+
+input "table_a" {
+  SELECT 'config_query' AS some_column, 1 AS some_id
+}
+
+input "table_b" {
+  SELECT 1 AS some_id
+}
+
+SELECT 'config_query' AS some_column, 1 AS some_id

--- a/test/fixtures/dataform/expected_output/assertion.sql
+++ b/test/fixtures/dataform/expected_output/assertion.sql
@@ -1,0 +1,3 @@
+
+
+SELECT * FROM `project.dataset.table_a` WHERE col IS NULL

--- a/test/fixtures/dataform/expected_output/declaration.sql
+++ b/test/fixtures/dataform/expected_output/declaration.sql
@@ -1,0 +1,4 @@
+
+
+-- This is a comment that should be preserved.
+-- TODO: Check if this linting works.

--- a/test/fixtures/dataform/expected_output/incremental.sql
+++ b/test/fixtures/dataform/expected_output/incremental.sql
@@ -1,0 +1,3 @@
+
+-- This inserts `1` the first time running, and `2` on subsequent runs.
+SELECT 2 AS col

--- a/test/fixtures/dataform/expected_output/pre_post_ops.sql
+++ b/test/fixtures/dataform/expected_output/pre_post_ops.sql
@@ -1,0 +1,7 @@
+
+
+
+
+
+
+SELECT 1 AS test

--- a/test/fixtures/dataform/expected_output/test_case.sql
+++ b/test/fixtures/dataform/expected_output/test_case.sql
@@ -1,0 +1,7 @@
+
+
+
+
+
+
+SELECT 'config_query' AS some_column, 1 AS some_id

--- a/test/templater_test.py
+++ b/test/templater_test.py
@@ -42,6 +42,11 @@ def _run_templater_and_verify_result(
         "no_template.sqlx",
         "sql_line_comment_ignored.sqlx",
         "sql_block_comment_ignored.sqlx",
+        "pre_post_ops.sqlx",
+        "incremental.sqlx",
+        "assertion.sqlx",
+        "declaration.sqlx",
+        "test_case.sqlx",
     ],
 )
 def test__templater_dataform_templating_result(


### PR DESCRIPTION
Added support for Dataform test, assertion, incremental, and operations types in the templater.
Add support for input blocks in Dataform tests.
Added test cases for declarations, assertions, incremental tables, operations, and tests to ensure correct templating.