### PR TITLE
Fix mypy fail on Python 3.10+ and expand CI to 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ warn_unused_configs = true
 ignore_missing_imports = true
 exclude = ["build", ".venv", ".ruff_cache"]
 
+[[tool.mypy.overrides]]
+module = ["_pytest.*", "pytest.*"]
+follow_imports = "skip"
+
 [tool.basedpyright]
 exclude = [ "**/__pycache__", "build", ".ruff_cache"]
 pythonVersion = "3.9"


### PR DESCRIPTION
- Skip mypy import traversal into pytest internals to fix `python_version = "3.9"` incompatibility with pytest's use of `match` statements
- Expand CI matrix to Python 3.14